### PR TITLE
Created RevisionAuditTool

### DIFF
--- a/config/module.config.php
+++ b/config/module.config.php
@@ -51,6 +51,8 @@ return [
                 => Tools\TriggerToolFactory::class,
             Tools\EpochTool::class
                 => Tools\EpochToolFactory::class,
+            Tools\RevisionAuditTool::class
+                => Tools\RevisionAuditToolFactory::class,
             EventListener\PostFlush::class
                 => EventListener\PostFlushFactory::class,
             EventListener\PostConnect::class

--- a/src/EventListener/PostFlush.php
+++ b/src/EventListener/PostFlush.php
@@ -2,14 +2,11 @@
 
 namespace ZF\Doctrine\Audit\EventListener;
 
-use Zend\Authentication\AuthenticationService;
-
 use Doctrine\ORM\Event\PostFlushEventArgs;
 use Doctrine\ORM\Query\ResultSetMapping;
-use ZF\OAuth2\Doctrine\Identity\AuthenticatedIdentity as OAuth2AuthenticatedIdentity;
-use ZF\MvcAuth\Identity\AuthenticatedIdentity;
-use ZF\MvcAuth\Identity\GuestIdentity;
-use ZF\Doctrine\Audit\RevisionComment;
+use ZF\Doctrine\Audit\Tools\RevisionAuditTool;
+use ZF\Doctrine\Audit\Persistence\RevisionAuditToolAwareInterface;
+use ZF\Doctrine\Audit\Persistence\RevisionAuditToolAwareTrait;
 
 /**
  * After each change to the database the revision entity stays
@@ -22,65 +19,22 @@ use ZF\Doctrine\Audit\RevisionComment;
  * auditing.  You will still need to use native query
  * because doctrine createQuery expects a FROM clause.
  */
-final class PostFlush
+final class PostFlush implements RevisionAuditToolAwareInterface
 {
-    private $authenticationService;
-    private $revisionComment;
+    use RevisionAuditToolAwareTrait;
+
     private $enable = true;
 
-    public function __construct(RevisionComment $revisionComment, AuthenticationService $authenticationService = null)
+    public function __construct(RevisionAuditTool $revisionAuditTool)
     {
-        $this->revisionComment = $revisionComment;
-        $this->authenticationService = $authenticationService;
+        $this->setRevisionAuditTool($revisionAuditTool);
     }
 
     public function postFlush(PostFlushEventArgs $args)
     {
-        $userId = 0;
-        $userName = 'guest';
-        $userEmail = '';
-
-        if ($this->authenticationService->getIdentity() instanceof OAuth2AuthenticatedIdentity) {
-            $user = $this->authenticationService->getIdentity()->getUser();
-
-            if (method_exists($user, 'getId')) {
-                $userId = $user->getId();
-            }
-
-            if (method_exists($user, 'getDisplayName')) {
-                $userName = $user->getDisplayName();
-            }
-
-            if (method_exists($user, 'getEmail')) {
-                $userEmail = $user->getEmail();
-            }
-        } elseif ($this->authenticationService->getIdentity() instanceof AuthenticatedIdentity) {
-            $userId = $this->authenticationService->getIdentity()->getAuthenticationIdentity()['user_id'];
-            $userName = $this->authenticationService->getIdentity()->getName();
-        } elseif ($this->authenticationService->getIdentity() instanceof GuestIdentity) {
-        } else {
-            // Is null or other identity
-        }
-
-        $query = $args->getEntityManager()
-            ->createNativeQuery(
-                "
-                SELECT close_revision_audit(:userId, :userName, :userEmail, :comment)
-            ",
-                new ResultSetMapping()
-            )
-            ->setParameter('userId', $userId)
-            ->setParameter('userName', $userName)
-            ->setParameter('userEmail', $userEmail)
-            ->setParameter('comment', $this->revisionComment->getComment());
-        ;
-
         if ($this->enable) {
-            $query->getResult();
+            $this->getRevisionAuditTool()->close();
         }
-
-        // Reset the revision comment
-        $this->revisionComment->setComment('');
     }
 
     public function enable()

--- a/src/EventListener/PostFlushFactory.php
+++ b/src/EventListener/PostFlushFactory.php
@@ -5,16 +5,15 @@ namespace ZF\Doctrine\Audit\EventListener;
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Factory\FactoryInterface;
 use Zend\ServiceManager\Exception\ServiceNotFoundException;
-use ZF\Doctrine\Audit\RevisionComment;
+use ZF\Doctrine\Audit\Tools\RevisionAuditTool;
 
 class PostFlushFactory implements
     FactoryInterface
 {
     public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
     {
-        $authentication = $container->get('authentication');
-        $revisionComment = $container->get(RevisionComment::class);
+        $revisionAuditTool = $container->get(RevisionAuditTool::class);
 
-        return new $requestedName($revisionComment, $authentication);
+        return new $requestedName($revisionAuditTool);
     }
 }

--- a/src/Persistence/RevisionAuditToolAwareInterface.php
+++ b/src/Persistence/RevisionAuditToolAwareInterface.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace ZF\Doctrine\Audit\Persistence;
+
+use ZF\Doctrine\Audit\Tools\RevisionAuditTool;
+
+interface RevisionAuditToolAwareInterface
+{
+    public function setRevisionAuditTool(RevisionAuditTool $revisionAuditTool);
+    public function getRevisionAuditTool(): RevisionAuditTool;
+}

--- a/src/Persistence/RevisionAuditToolAwareTrait.php
+++ b/src/Persistence/RevisionAuditToolAwareTrait.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace ZF\Doctrine\Audit\Persistence;
+
+use ZF\Doctrine\Audit\Tools\RevisionAuditTool;
+
+trait RevisionAuditToolAwareTrait
+{
+    protected $revisionAuditTool;
+
+    public function setRevisionAuditTool(RevisionAuditTool $revisionAuditTool)
+    {
+        $this->revisionAuditTool = $revisionAuditTool;
+
+        return $this;
+    }
+
+    public function getRevisionAuditTool(): RevisionAuditTool
+    {
+        return $this->revisionAuditTool;
+    }
+}

--- a/src/Plugin/AuditPlugin.php
+++ b/src/Plugin/AuditPlugin.php
@@ -2,17 +2,28 @@
 
 namespace ZF\Doctrine\Audit\Plugin;
 
+use Zend\Authentication\AuthenticationService;
+use Doctrine\Common\Collections\ArrayCollection;
+use Doctrine\ORM\Query\ResultSetMapping;
 use ZF\Doctrine\Repository\Plugin\PluginInterface;
 use ZF\Doctrine\Audit\Persistence\AuditObjectManagerAwareInterface;
 use ZF\Doctrine\Audit\Persistence\AuditObjectManagerAwareTrait;
+use ZF\Doctrine\Audit\Persistence\RevisionAuditToolAwareInterface;
+use ZF\Doctrine\Audit\Persistence\RevisionAuditToolAwareTrait;
+use ZF\Doctrine\Audit\Persistence\RevisionCommentAwareInterface;
+use ZF\Doctrine\Audit\Persistence\RevisionCommentAwareTrait;
 use ZF\Doctrine\Audit\Entity\AuditEntity;
-use Doctrine\Common\Collections\ArrayCollection;
+use ZF\Doctrine\Audit\RevisionComment;
 
 class AuditPlugin implements
     PluginInterface,
-    AuditObjectManagerAwareInterface
+    AuditObjectManagerAwareInterface,
+    RevisionAuditToolAwareInterface,
+    RevisionCommentAwareInterface
 {
     use AuditObjectManagerAwareTrait;
+    use RevisionAuditToolAwareTrait;
+    use RevisionCommentAwareTrait;
 
     protected $repository;
     protected $parameters;

--- a/src/Plugin/AuditPluginFactory.php
+++ b/src/Plugin/AuditPluginFactory.php
@@ -4,6 +4,8 @@ namespace ZF\Doctrine\Audit\Plugin;
 
 use Interop\Container\ContainerInterface;
 use Zend\ServiceManager\Factory\FactoryInterface;
+use ZF\Doctrine\Audit\RevisionComment;
+use ZF\Doctrine\Audit\Tools\RevisionAuditTool;
 
 class AuditPluginFactory implements
     FactoryInterface
@@ -14,6 +16,8 @@ class AuditPluginFactory implements
 
         $instance = new $requestedName($options);
         $instance->setAuditObjectManager($container->get($config['audit_object_manager']));
+        $instance->setRevisionComment($container->get(RevisionComment::class));
+        $instance->setRevisionAuditTool($container->get(RevisionAuditTool::class));
 
         return $instance;
     }

--- a/src/Tools/RevisionAuditTool.php
+++ b/src/Tools/RevisionAuditTool.php
@@ -1,0 +1,86 @@
+<?php
+
+namespace ZF\Doctrine\Audit\Tools;
+
+use Zend\View\Renderer\RendererInterface;
+use Zend\Authentication\AuthenticationService;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ORM\Query\ResultSetMapping;
+use ZF\OAuth2\Doctrine\Identity\AuthenticatedIdentity as OAuth2AuthenticatedIdentity;
+use ZF\MvcAuth\Identity\AuthenticatedIdentity;
+use ZF\MvcAuth\Identity\GuestIdentity;
+use ZF\Doctrine\Audit\Persistence;
+use ZF\Doctrine\Audit\AuditOptions;
+use ZF\Doctrine\Audit\RevisionComment;
+
+final class RevisionAuditTool implements
+    Persistence\ObjectManagerAwareInterface,
+    Persistence\RevisionCommentAwareInterface
+{
+    use Persistence\ObjectManagerAwareTrait;
+    use Persistence\RevisionCommentAwareTrait;
+
+    private $authenticationService;
+
+    public function __construct(
+        ObjectManager $objectManager,
+        RevisionComment $revisionComment,
+        AuthenticationService $authenticationService = null
+    ) {
+        $this->setObjectManager($objectManager);
+        $this->setRevisionComment($revisionComment);
+        $this->authenticationService = $authenticationService;
+    }
+
+    /**
+     * Close a revision - can be done manually or automatically via postFlush
+     */
+    public function close()
+    {
+        $userId = 0;
+        $userName = 'guest';
+        $userEmail = '';
+
+        if ($this->authenticationService) {
+            if ($this->authenticationService->getIdentity() instanceof OAuth2AuthenticatedIdentity) {
+                $user = $this->authenticationService->getIdentity()->getUser();
+
+                if (method_exists($user, 'getId')) {
+                    $userId = $user->getId();
+                }
+
+                if (method_exists($user, 'getDisplayName')) {
+                    $userName = $user->getDisplayName();
+                }
+
+                if (method_exists($user, 'getEmail')) {
+                    $userEmail = $user->getEmail();
+                }
+            } elseif ($this->authenticationService->getIdentity() instanceof AuthenticatedIdentity) {
+                $userId = $this->authenticationService->getIdentity()->getAuthenticationIdentity()['user_id'];
+                $userName = $this->authenticationService->getIdentity()->getName();
+            } elseif ($this->authenticationService->getIdentity() instanceof GuestIdentity) {
+            } else {
+                // Is null or other identity
+            }
+        }
+
+        $query = $this->getObjectManager()
+            ->createNativeQuery(
+                "
+                SELECT close_revision_audit(:userId, :userName, :userEmail, :comment)
+            ",
+                new ResultSetMapping()
+            )
+            ->setParameter('userId', $userId)
+            ->setParameter('userName', $userName)
+            ->setParameter('userEmail', $userEmail)
+            ->setParameter('comment', $this->revisionComment->getComment());
+        ;
+
+        $query->getResult();
+
+        // Reset the revision comment
+        $this->revisionComment->setComment('');
+    }
+}

--- a/src/Tools/RevisionAuditToolFactory.php
+++ b/src/Tools/RevisionAuditToolFactory.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace ZF\Doctrine\Audit\Tools;
+
+use Exception;
+use Interop\Container\ContainerInterface;
+use Zend\ServiceManager\Factory\FactoryInterface;
+use ZF\Doctrine\Audit\AuditOptions;
+use ZF\Doctrine\Audit\RevisionComment;
+
+class RevisionAuditToolFactory implements
+    FactoryInterface
+{
+    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    {
+        $config = $container->get('config')['zf-doctrine-audit'];
+
+        $objectManager = $container->get($config['target_object_manager']);
+        $revisionComment = $container->get(RevisionComment::class);
+
+        $authentication = null;
+        try {
+            $authentication = $container->get('authentication');
+        } catch (Exception $e) {
+        }
+
+        return new $requestedName($objectManager, $revisionComment, $authentication);
+    }
+}


### PR DESCRIPTION
This tool has the method close() which closes an open Revision Audit.  This can now be called from the Plugin or via the postFlush.